### PR TITLE
Fix Error Propagation from run.js

### DIFF
--- a/lib/invoke/local.js
+++ b/lib/invoke/local.js
@@ -76,6 +76,20 @@ const invoke = (func, event, lambdaEndpoint, logger) => {
 
       return BbPromise.reject(new Error('Error executing function'))
     }
+  }).catch((result) => {
+    try {
+      const output = result.stdout ? JSON.parse(result.stdout) : null
+
+      if (output && output.errorMessage !== null && output.errorMessage !== undefined) {
+        return BbPromise.reject(new Error(output.errorMessage))
+      }
+
+      return BbPromise.reject(output)
+    } catch (err) {
+      log(err)
+
+      return BbPromise.reject(new Error('Error executing function'))
+    }
   })
 }
 


### PR DESCRIPTION
Fix Error Propagation from run.js when return code !== 0

https://github.com/serverless-community-labs/serverless-plugin-simulate/blob/9579e5dabb5b8b0fb2fcdcbe747325057ec43e5e/lib/invoke/run.js#L69-L72